### PR TITLE
Unset variables at the end of the foreach loop

### DIFF
--- a/cronjobs/generate.php
+++ b/cronjobs/generate.php
@@ -275,6 +275,10 @@ foreach ( $siteaccesses as $siteaccess )
         $lastmod = $dom->createTextNode( $modified );
         $lastmod = $subNode->appendChild( $lastmod );
     }
+    
+    // Remove old variables to release memory
+    unset($nodeArray);
+    eZContentObject::clearCache();
 
     /**
      * BC: Build output xml data file name


### PR DESCRIPTION
When running the cronjob script on many siteaccesses at once, there's a risk of fatal error (Memory exhausted).
Unsetting heavy variables and clearing eZ ContentObjectCache releases memory before generating the sitemap for an other siteaccess.